### PR TITLE
CI: Don't enable color explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@ on:
   push:
   pull_request:
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
   clippy:
     name: Clippy


### PR DESCRIPTION
This is done as part of dtolnay/rust-toolchain