### PR TITLE
add support to boot RustyHermit on Firecracker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermit-entry"
-version = "0.9.2"
+version = "0.10.0"
 authors = ["Martin Kröning <mkroening@posteo.net>"]
 edition = "2021"
 description = "RustyHermit's entry API."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermit-entry"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Martin Kröning <mkroening@posteo.net>"]
 edition = "2021"
 description = "RustyHermit's entry API."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermit-entry"
-version = "0.10.0"
+version = "0.9.2"
 authors = ["Martin Kröning <mkroening@posteo.net>"]
 edition = "2021"
 description = "RustyHermit's entry API."

--- a/src/boot_info/kernel.rs
+++ b/src/boot_info/kernel.rs
@@ -68,6 +68,24 @@ impl From<RawPlatformInfo> for PlatformInfo {
                 cpu_freq,
                 boot_time: OffsetDateTime::from_unix_timestamp_nanos(boot_time).unwrap(),
             },
+            RawPlatformInfo::LinuxBootParams {
+                command_line_data,
+                command_line_len,
+                boot_params_addr,
+            } => {
+                let command_line = (!command_line_data.is_null()).then(|| {
+                    // SAFETY: cmdline and cmdsize are valid forever.
+                    let slice = unsafe {
+                        core::slice::from_raw_parts(command_line_data, command_line_len as usize)
+                    };
+                    core::str::from_utf8(slice).unwrap()
+                });
+
+                Self::LinuxBootParams {
+                    command_line,
+                    boot_params_addr,
+                }
+            }
         }
     }
 }

--- a/src/boot_info/loader.rs
+++ b/src/boot_info/loader.rs
@@ -56,6 +56,16 @@ impl From<PlatformInfo> for RawPlatformInfo {
                 cpu_freq,
                 boot_time: boot_time.unix_timestamp_nanos(),
             },
+            PlatformInfo::LinuxBootParams {
+                command_line,
+                boot_params_addr,
+            } => Self::LinuxBootParams {
+                command_line_data: command_line
+                    .map(|s| s.as_ptr())
+                    .unwrap_or(core::ptr::null()),
+                command_line_len: command_line.map(|s| s.len() as u64).unwrap_or(0),
+                boot_params_addr,
+            },
         }
     }
 }

--- a/src/boot_info/mod.rs
+++ b/src/boot_info/mod.rs
@@ -97,6 +97,14 @@ pub enum PlatformInfo {
         /// Boot time.
         boot_time: OffsetDateTime,
     },
+    /// Usage of    Linux Boot Parameters
+    LinuxBootParams {
+        /// Command line passed to the kernel.
+        command_line: Option<&'static str>,
+
+        /// Address to Linux boot parameters.
+        boot_params_addr: core::num::NonZeroU64,
+    },
 }
 
 /// Thread local storage (TLS) image information.
@@ -163,5 +171,10 @@ enum RawPlatformInfo {
         num_cpus: NonZeroU64,
         cpu_freq: Option<NonZeroU32>,
         boot_time: i128,
+    },
+    LinuxBootParams {
+        command_line_data: *const u8,
+        command_line_len: u64,
+        boot_params_addr: core::num::NonZeroU64,
     },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,3 +40,21 @@ const NT_HERMIT_ENTRY_VERSION: u32 = 0x5a00;
 /// The current hermit entry version.
 #[cfg_attr(not(all(feature = "loader", feature = "kernel")), allow(dead_code))]
 const HERMIT_ENTRY_VERSION: u8 = 2;
+
+/// Offsets and values used to interpret the boot params ("zeropage") setup by firecracker
+/// For the full list of values see
+/// https://github.com/torvalds/linux/blob/b6839ef26e549de68c10359d45163b0cfb031183/arch/x86/include/uapi/asm/bootparam.h#L151-L198
+#[allow(missing_docs)]
+pub mod fc {
+    pub const LINUX_KERNEL_BOOT_FLAG_MAGIC: u16 = 0xaa55;
+    pub const LINUX_KERNEL_HRD_MAGIC: u32 = 0x53726448;
+    pub const LINUX_SETUP_HEADER_OFFSET: usize = 0x1f1;
+    pub const BOOT_FLAG_OFFSET: usize = 13;
+    pub const HDR_MAGIC_OFFSET: usize = 17;
+    pub const E820_ENTRIES_OFFSET: usize = 0x1e8;
+    pub const E820_TABLE_OFFSET: usize = 0x2d0;
+    pub const RAMDISK_IMAGE_OFFSET: usize = 39;
+    pub const RAMDISK_SIZE_OFFSET: usize = 43;
+    pub const CMD_LINE_PTR_OFFSET: usize = 55;
+    pub const CMD_LINE_SIZE_OFFSET: usize = 71;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ const NT_HERMIT_ENTRY_VERSION: u32 = 0x5a00;
 
 /// The current hermit entry version.
 #[cfg_attr(not(all(feature = "loader", feature = "kernel")), allow(dead_code))]
-const HERMIT_ENTRY_VERSION: u8 = 2;
+const HERMIT_ENTRY_VERSION: u8 = 3;
 
 /// Offsets and values used to interpret the boot params ("zeropage") setup by firecracker
 /// For the full list of values see

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ const HERMIT_ENTRY_VERSION: u8 = 2;
 
 /// Offsets and values used to interpret the boot params ("zeropage") setup by firecracker
 /// For the full list of values see
-/// https://github.com/torvalds/linux/blob/b6839ef26e549de68c10359d45163b0cfb031183/arch/x86/include/uapi/asm/bootparam.h#L151-L198
+/// <https://github.com/torvalds/linux/blob/b6839ef26e549de68c10359d45163b0cfb031183/arch/x86/include/uapi/asm/bootparam.h#L151-L198>
 #[allow(missing_docs)]
 pub mod fc {
     pub const LINUX_KERNEL_BOOT_FLAG_MAGIC: u16 = 0xaa55;


### PR DESCRIPTION
In case of Firecracker, RustyHermit has to emulate the boot process of Linux. Consequently, rusty-loader forwards the Linux boot params to RustyHermit.