### PR TITLE
fix(config): Fix invalid `copy_from_slice` invocation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -146,7 +146,7 @@ pub fn parse_tar(image: &[u8]) -> Result<ConfigHandle<'_>, ParseTarError> {
             if f.len() >= 256 {
                 return Ok(None);
             }
-            tmp.copy_from_slice(f);
+            tmp[..f.len()].copy_from_slice(f);
             tar_no_std::TarFormatString::new(tmp)
         };
 


### PR DESCRIPTION
As this was the only problem in `hermit-entry` I ran into while testing `uhyve`'s internal Hermit image mode, this shouldn't need any additional amendments. After this is merged, a patch release of `hermit-entry` is necessary, however.